### PR TITLE
feat: spawn from anywhere

### DIFF
--- a/ab/src/main.rs
+++ b/ab/src/main.rs
@@ -279,7 +279,7 @@ fn run() -> eyre::Result<()> {
                 // Otherwise, use the current directory directly.
                 // No base_repo_dir lookup is required.
                 let cwd = std::env::current_dir()?;
-                let path = agent_box_common::repo::find_git_root().unwrap_or(cwd);
+                let path = agent_box_common::repo::find_git_root(false).unwrap_or(cwd);
                 (path.clone(), path)
             } else {
                 // In session mode, we need a valid repo_id in base_repo_dir

--- a/ab/src/main.rs
+++ b/ab/src/main.rs
@@ -3,8 +3,10 @@ use agent_box_common::config::{
     validate_config_or_err,
 };
 use agent_box_common::display::info;
-use agent_box_common::path::WorkspaceType;
-use agent_box_common::repo::{locate_repo, new_workspace, remove_repo, resolve_repo_id};
+use agent_box_common::path::{WorkspaceType, expand_path};
+use agent_box_common::repo::{
+    locate_repo, new_workspace, pick_discovered_repo, remove_repo, resolve_repo_id,
+};
 use clap::{Parser, Subcommand};
 use eyre::Result;
 use std::path::PathBuf;
@@ -49,6 +51,11 @@ fn maybe_start_managed_portal(
 #[command(name = "ab")]
 #[command(about = "Agent Box - Git repository management tool")]
 struct Cli {
+    /// Additional directories to scan for repository discovery.
+    /// Can be specified multiple times.
+    #[arg(long = "repo-discovery-dir", value_name = "PATH")]
+    repo_discovery_dir: Vec<PathBuf>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -166,6 +173,8 @@ enum DbgCommands {
     },
     /// Validate configuration (profiles, extends, default_profile)
     Validate,
+    /// Pick from discovered repositories via interactive selector (fzf/inquire)
+    Pick,
     /// Show resolved/merged configuration from profiles
     Resolve {
         /// Profiles to apply (can be specified multiple times).
@@ -203,7 +212,16 @@ fn main() {
 
 fn run() -> eyre::Result<()> {
     let cli = Cli::parse();
-    let config = load_config()?;
+    let mut config = load_config()?;
+
+    if !cli.repo_discovery_dir.is_empty() {
+        let extra_dirs = cli
+            .repo_discovery_dir
+            .iter()
+            .map(|p| expand_path(p))
+            .collect::<Result<Vec<_>>>()?;
+        config.repo_discovery_dirs.extend(extra_dirs);
+    }
 
     match cli.command {
         Commands::Info => {
@@ -417,6 +435,10 @@ fn run() -> eyre::Result<()> {
                     );
                     std::process::exit(1);
                 }
+            }
+            DbgCommands::Pick => {
+                let repo_id = pick_discovered_repo(&config)?;
+                println!("{}", repo_id.relative_path().display());
             }
             DbgCommands::Resolve { profile } => {
                 // Validate config first

--- a/ab/src/runtime/mod.rs
+++ b/ab/src/runtime/mod.rs
@@ -1446,6 +1446,7 @@ mod tests {
         let config = Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: agent_box_common::config::RuntimeConfig {
@@ -1480,6 +1481,7 @@ mod tests {
         let config = Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: agent_box_common::config::RuntimeConfig {
@@ -1524,6 +1526,7 @@ mod tests {
         let config = Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1619,6 +1622,7 @@ mod tests {
         let config = Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1696,6 +1700,7 @@ mod tests {
         let config = Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1796,6 +1801,7 @@ mod tests {
         let config = Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1870,6 +1876,7 @@ mod tests {
         let config = Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1947,6 +1954,7 @@ mod tests {
         let config = Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {

--- a/ab/src/runtime/mod.rs
+++ b/ab/src/runtime/mod.rs
@@ -1447,6 +1447,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: agent_box_common::config::RuntimeConfig {
@@ -1482,6 +1483,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: agent_box_common::config::RuntimeConfig {
@@ -1527,6 +1529,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1623,6 +1626,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1701,6 +1705,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1802,6 +1807,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1877,6 +1883,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {
@@ -1955,6 +1962,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {

--- a/common/config.schema.json
+++ b/common/config.schema.json
@@ -75,6 +75,13 @@
         "type": "string"
       }
     },
+    "repo_discovery_timeout_secs": {
+      "description": "Timeout (seconds) for repository discovery scan per configured discovery root.",
+      "type": "integer",
+      "format": "uint64",
+      "default": 5,
+      "minimum": 0
+    },
     "runtime": {
       "$ref": "#/$defs/RuntimeConfig"
     },

--- a/common/config.schema.json
+++ b/common/config.schema.json
@@ -4,7 +4,8 @@
   "type": "object",
   "properties": {
     "base_repo_dir": {
-      "type": "string"
+      "type": "string",
+      "default": "/"
     },
     "context": {
       "description": "Root-level context",
@@ -74,8 +75,7 @@
     }
   },
   "required": [
-    "workspace_dir",
-    "base_repo_dir"
+    "workspace_dir"
   ],
   "$defs": {
     "ClipboardConfig": {

--- a/common/config.schema.json
+++ b/common/config.schema.json
@@ -67,6 +67,14 @@
         "$ref": "#/$defs/ProfileConfig"
       }
     },
+    "repo_discovery_dirs": {
+      "description": "Additional directories to scan when discovering repositories for interactive\nselection and disambiguation. If empty, only base_repo_dir is used.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "runtime": {
       "$ref": "#/$defs/RuntimeConfig"
     },
@@ -350,6 +358,17 @@
         "backend": {
           "type": "string",
           "default": "podman"
+        },
+        "dns": {
+          "description": "DNS servers to use inside the container (passed as `--dns` to the runtime).\nWhen set, the runtime generates `/etc/resolv.conf` from these servers\ninstead of copying the host's configuration.",
+          "type": "array",
+          "default": [
+            "1.1.1.1",
+            "8.8.8.8"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "entrypoint": {
           "type": [

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -837,7 +837,7 @@ pub fn load_config() -> Result<Config> {
     let global_config_path = PathBuf::from(&home).join(".agent-box.toml");
 
     // Find repo-local config if present (silently ignore if not in a git repo)
-    let repo_config_path = find_git_root()
+    let repo_config_path = find_git_root(false)
         .ok()
         .map(|root| root.join(".agent-box.toml"));
 

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -560,6 +560,10 @@ fn default_base_repo_dir() -> PathBuf {
     PathBuf::from("/")
 }
 
+fn default_repo_discovery_dirs() -> Vec<PathBuf> {
+    Vec::new()
+}
+
 #[derive(Debug, Deserialize, Default, Clone, PartialEq, JsonSchema)]
 pub struct RuntimeConfig {
     #[serde(default = "default_backend")]
@@ -596,6 +600,11 @@ pub struct Config {
     #[serde(default = "default_base_repo_dir")]
     #[schemars(default = "default_base_repo_dir")]
     pub base_repo_dir: PathBuf,
+    /// Additional directories to scan when discovering repositories for interactive
+    /// selection and disambiguation. If empty, only base_repo_dir is used.
+    #[serde(default = "default_repo_discovery_dirs")]
+    #[schemars(default = "default_repo_discovery_dirs")]
+    pub repo_discovery_dirs: Vec<PathBuf>,
     /// Default profile name to always apply (if set)
     #[serde(default)]
     pub default_profile: Option<String>,
@@ -836,6 +845,11 @@ pub fn load_config() -> Result<Config> {
         expand_path(&config.workspace_dir).wrap_err("Failed to expand workspace_dir path")?;
     config.base_repo_dir =
         expand_path(&config.base_repo_dir).wrap_err("Failed to expand base_repo_dir path")?;
+    config.repo_discovery_dirs = config
+        .repo_discovery_dirs
+        .iter()
+        .map(|p| expand_path(p).wrap_err("Failed to expand repo_discovery_dirs path"))
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(config)
 }
@@ -1546,6 +1560,7 @@ mod tests {
         Config {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
+            repo_discovery_dirs: vec![],
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -556,6 +556,10 @@ fn default_dns() -> Vec<String> {
     vec!["1.1.1.1".to_string(), "8.8.8.8".to_string()]
 }
 
+fn default_base_repo_dir() -> PathBuf {
+    PathBuf::from("/")
+}
+
 #[derive(Debug, Deserialize, Default, Clone, PartialEq, JsonSchema)]
 pub struct RuntimeConfig {
     #[serde(default = "default_backend")]
@@ -589,6 +593,8 @@ pub struct RuntimeConfig {
 #[derive(Debug, Deserialize, PartialEq, JsonSchema)]
 pub struct Config {
     pub workspace_dir: PathBuf,
+    #[serde(default = "default_base_repo_dir")]
+    #[schemars(default = "default_base_repo_dir")]
     pub base_repo_dir: PathBuf,
     /// Default profile name to always apply (if set)
     #[serde(default)]
@@ -1043,6 +1049,31 @@ mod tests {
                 config.runtime.mounts.ro.home_relative,
                 vec!["~/.config/git"]
             );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_base_repo_dir_defaults_to_root() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "global.toml",
+                r#"
+                workspace_dir = "/workspaces"
+
+                [runtime]
+                backend = "docker"
+                image = "test:latest"
+                "#,
+            )?;
+
+            let global_path = jail.directory().join("global.toml");
+            let figment = build_figment(&global_path, None);
+            let config: Config = figment.extract()?;
+
+            assert_eq!(config.workspace_dir, PathBuf::from("/workspaces"));
+            assert_eq!(config.base_repo_dir, PathBuf::from("/"));
 
             Ok(())
         });

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -564,6 +564,10 @@ fn default_repo_discovery_dirs() -> Vec<PathBuf> {
     Vec::new()
 }
 
+fn default_repo_discovery_timeout_secs() -> u64 {
+    5
+}
+
 #[derive(Debug, Deserialize, Default, Clone, PartialEq, JsonSchema)]
 pub struct RuntimeConfig {
     #[serde(default = "default_backend")]
@@ -605,6 +609,10 @@ pub struct Config {
     #[serde(default = "default_repo_discovery_dirs")]
     #[schemars(default = "default_repo_discovery_dirs")]
     pub repo_discovery_dirs: Vec<PathBuf>,
+    /// Timeout (seconds) for repository discovery scan per configured discovery root.
+    #[serde(default = "default_repo_discovery_timeout_secs")]
+    #[schemars(default = "default_repo_discovery_timeout_secs")]
+    pub repo_discovery_timeout_secs: u64,
     /// Default profile name to always apply (if set)
     #[serde(default)]
     pub default_profile: Option<String>,
@@ -1561,6 +1569,7 @@ mod tests {
             workspace_dir: PathBuf::from("/workspaces"),
             base_repo_dir: PathBuf::from("/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             default_profile: None,
             profiles: HashMap::new(),
             runtime: RuntimeConfig {

--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -3,6 +3,7 @@ use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use crate::config::Config;
 
@@ -112,7 +113,12 @@ impl RepoIdentifier {
 
     /// Helper function to discover repositories in a directory based on a filter predicate
     /// Stops descending into directories that are already repos.
-    fn discover_repos_in_dir<F>(base_dir: &Path, is_repo: F) -> Result<Vec<Self>>
+    fn discover_repos_in_dir<F>(
+        base_dir: &Path,
+        is_repo: F,
+        timeout: Duration,
+        started_at: Instant,
+    ) -> Result<Vec<Self>>
     where
         F: Fn(&Path) -> bool + Copy,
     {
@@ -150,6 +156,13 @@ impl RepoIdentifier {
             });
 
         for entry in walker.filter_map(|e| e.ok()) {
+            if started_at.elapsed() > timeout {
+                return Err(eyre!(
+                    "Repository discovery timed out after {}s while scanning {}. Narrow repo_discovery_dirs or increase repo_discovery_timeout_secs in your config.",
+                    timeout.as_secs(),
+                    base_dir.display()
+                ));
+            }
             let path = entry.path();
 
             if !path.is_dir() || !is_repo(path) {
@@ -185,13 +198,47 @@ impl RepoIdentifier {
 
         let mut seen = BTreeSet::new();
         let mut repos = Vec::new();
+        let timeout = Duration::from_secs(config.repo_discovery_timeout_secs);
+        let started_at = Instant::now();
+        let mut per_dir_timings: Vec<(PathBuf, Duration)> = Vec::new();
 
         for dir in discovery_dirs {
-            for repo in Self::discover_repos_in_dir(dir, |path| {
-                path.join(".git").exists() || path.join(".jj").exists()
-            })? {
-                if seen.insert((repo.discovery_base_dir.clone(), repo.relative_path.clone())) {
-                    repos.push(repo);
+            let dir_started_at = Instant::now();
+            let discovered = Self::discover_repos_in_dir(
+                dir,
+                |path| path.join(".git").exists() || path.join(".jj").exists(),
+                timeout,
+                started_at,
+            );
+
+            match discovered {
+                Ok(found) => {
+                    per_dir_timings.push((dir.to_path_buf(), dir_started_at.elapsed()));
+                    for repo in found {
+                        if seen
+                            .insert((repo.discovery_base_dir.clone(), repo.relative_path.clone()))
+                        {
+                            repos.push(repo);
+                        }
+                    }
+                }
+                Err(e) => {
+                    let current_elapsed = dir_started_at.elapsed();
+                    let mut timing_parts: Vec<String> = per_dir_timings
+                        .iter()
+                        .map(|(p, d)| format!("{}: {}ms", p.display(), d.as_millis()))
+                        .collect();
+                    timing_parts.push(format!(
+                        "{}: {}ms (timed out)",
+                        dir.display(),
+                        current_elapsed.as_millis()
+                    ));
+
+                    return Err(eyre!(
+                        "{}\nPer-directory scan timings: {}",
+                        e,
+                        timing_parts.join(", ")
+                    ));
                 }
             }
         }
@@ -349,6 +396,7 @@ mod tests {
         Config {
             base_repo_dir: PathBuf::from("/home/user/repos"),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: HashMap::new(),
@@ -415,6 +463,7 @@ mod tests {
         let config = Config {
             base_repo_dir: base_repo_dir.clone(),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: std::collections::HashMap::new(),
@@ -459,6 +508,7 @@ mod tests {
         let config = Config {
             base_repo_dir: base_repo_dir.clone(),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: std::collections::HashMap::new(),
@@ -503,6 +553,7 @@ mod tests {
         let config = Config {
             base_repo_dir: base_repo_dir.clone(),
             repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 30,
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: std::collections::HashMap::new(),
@@ -555,6 +606,7 @@ mod tests {
         let config = Config {
             base_repo_dir: base_repo_dir.clone(),
             repo_discovery_dirs: vec![discover_dir.clone()],
+            repo_discovery_timeout_secs: 30,
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: std::collections::HashMap::new(),
@@ -597,6 +649,7 @@ mod tests {
         let config = Config {
             base_repo_dir: temp_dir.join("base"),
             repo_discovery_dirs: vec![d1.clone(), d2.clone()],
+            repo_discovery_timeout_secs: 30,
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: std::collections::HashMap::new(),

--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -1,6 +1,7 @@
 use eyre::{Result, eyre};
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::config::Config;
@@ -34,20 +35,29 @@ pub struct JjWorkspaceInfo {
 /// against different base directories (git_dir, jj_dir, workspace_dir, etc.)
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RepoIdentifier {
-    /// The relative path from any base directory (e.g., "myproject" or "work/project")
+    /// The relative path from discovery base directory (e.g., "myproject" or "work/project")
     pub relative_path: PathBuf,
+    /// Optional discovery base dir that this repo was found under.
+    /// When present, source_path() resolves against this directory.
+    pub discovery_base_dir: Option<PathBuf>,
 }
 
 impl RepoIdentifier {
     /// Create from a path within base_repo_dir
     pub fn from_repo_path(config: &Config, full_path: &Path) -> Result<Self> {
         let relative_path = calculate_relative_path(&config.base_repo_dir, full_path)?;
-        Ok(Self { relative_path })
+        Ok(Self {
+            relative_path,
+            discovery_base_dir: Some(config.base_repo_dir.clone()),
+        })
     }
 
     /// Get the full path in base_repo_dir (source repo location)
     pub fn source_path(&self, config: &Config) -> PathBuf {
-        config.base_repo_dir.join(&self.relative_path)
+        self.discovery_base_dir
+            .as_ref()
+            .unwrap_or(&config.base_repo_dir)
+            .join(&self.relative_path)
     }
 
     /// Get the full path for a git workspace with given session
@@ -153,18 +163,40 @@ impl RepoIdentifier {
 
             repos.push(Self {
                 relative_path: relative_path.to_path_buf(),
+                discovery_base_dir: Some(base_dir.to_path_buf()),
             });
         }
 
         Ok(repos)
     }
 
-    /// Discover all repositories in the base_repo_dir.
-    /// Returns a vector of RepoIdentifiers for all repositories found (with .git or .jj).
+    /// Discover all repositories in configured discovery directories.
+    /// Returns RepoIdentifiers for all repositories found (with .git or .jj).
     pub fn discover_repo_ids(config: &Config) -> Result<Vec<Self>> {
-        Self::discover_repos_in_dir(&config.base_repo_dir, |path| {
-            path.join(".git").exists() || path.join(".jj").exists()
-        })
+        let discovery_dirs: Vec<&Path> = if config.repo_discovery_dirs.is_empty() {
+            vec![config.base_repo_dir.as_path()]
+        } else {
+            config
+                .repo_discovery_dirs
+                .iter()
+                .map(PathBuf::as_path)
+                .collect()
+        };
+
+        let mut seen = BTreeSet::new();
+        let mut repos = Vec::new();
+
+        for dir in discovery_dirs {
+            for repo in Self::discover_repos_in_dir(dir, |path| {
+                path.join(".git").exists() || path.join(".jj").exists()
+            })? {
+                if seen.insert((repo.discovery_base_dir.clone(), repo.relative_path.clone())) {
+                    repos.push(repo);
+                }
+            }
+        }
+
+        Ok(repos)
     }
 
     /// Get all JJ workspaces for this repository using JJ's workspace tracking
@@ -316,6 +348,7 @@ mod tests {
 
         Config {
             base_repo_dir: PathBuf::from("/home/user/repos"),
+            repo_discovery_dirs: vec![],
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: HashMap::new(),
@@ -351,6 +384,7 @@ mod tests {
         let config = make_test_config();
         let id = RepoIdentifier {
             relative_path: PathBuf::from("work/project"),
+            discovery_base_dir: None,
         };
 
         assert_eq!(
@@ -380,6 +414,7 @@ mod tests {
 
         let config = Config {
             base_repo_dir: base_repo_dir.clone(),
+            repo_discovery_dirs: vec![],
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: std::collections::HashMap::new(),
@@ -423,6 +458,7 @@ mod tests {
 
         let config = Config {
             base_repo_dir: base_repo_dir.clone(),
+            repo_discovery_dirs: vec![],
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: std::collections::HashMap::new(),
@@ -466,6 +502,7 @@ mod tests {
 
         let config = Config {
             base_repo_dir: base_repo_dir.clone(),
+            repo_discovery_dirs: vec![],
             workspace_dir: PathBuf::from("/mnt/workspace"),
             default_profile: None,
             profiles: std::collections::HashMap::new(),
@@ -501,5 +538,89 @@ mod tests {
         // Test when base_repo_dir doesn't exist
         let matches = RepoIdentifier::find_matching(&config, "anything").unwrap();
         assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_discover_repo_ids_uses_repo_discovery_dirs() {
+        use crate::config::RuntimeConfig;
+
+        let temp_dir =
+            std::env::temp_dir().join(format!("ab-test-discovery-dirs-{}", std::process::id()));
+        let base_repo_dir = temp_dir.join("base");
+        let discover_dir = temp_dir.join("discover");
+
+        std::fs::create_dir_all(base_repo_dir.join("ignored")).unwrap();
+        std::fs::create_dir_all(discover_dir.join("fr").join("agent-box").join(".git")).unwrap();
+
+        let config = Config {
+            base_repo_dir: base_repo_dir.clone(),
+            repo_discovery_dirs: vec![discover_dir.clone()],
+            workspace_dir: PathBuf::from("/mnt/workspace"),
+            default_profile: None,
+            profiles: std::collections::HashMap::new(),
+            runtime: RuntimeConfig {
+                backend: "podman".to_string(),
+                image: "test:latest".to_string(),
+                entrypoint: None,
+                mounts: Default::default(),
+                skip_mounts: vec![],
+                env: Default::default(),
+                env_passthrough: vec![],
+                ports: Default::default(),
+                hosts: Default::default(),
+                dns: Default::default(),
+            },
+            context: String::new(),
+            context_path: "/tmp/context".to_string(),
+            portal: crate::portal::PortalConfig::default(),
+        };
+
+        let repos = RepoIdentifier::discover_repo_ids(&config).unwrap();
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].relative_path(), Path::new("fr/agent-box"));
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_discover_repo_ids_keeps_duplicates_across_discovery_dirs() {
+        use crate::config::RuntimeConfig;
+
+        let temp_dir =
+            std::env::temp_dir().join(format!("ab-test-discovery-dupes-{}", std::process::id()));
+        let d1 = temp_dir.join("d1");
+        let d2 = temp_dir.join("d2");
+
+        std::fs::create_dir_all(d1.join("fr").join("agent-box").join(".git")).unwrap();
+        std::fs::create_dir_all(d2.join("fr").join("agent-box").join(".git")).unwrap();
+
+        let config = Config {
+            base_repo_dir: temp_dir.join("base"),
+            repo_discovery_dirs: vec![d1.clone(), d2.clone()],
+            workspace_dir: PathBuf::from("/mnt/workspace"),
+            default_profile: None,
+            profiles: std::collections::HashMap::new(),
+            runtime: RuntimeConfig {
+                backend: "podman".to_string(),
+                image: "test:latest".to_string(),
+                entrypoint: None,
+                mounts: Default::default(),
+                skip_mounts: vec![],
+                env: Default::default(),
+                env_passthrough: vec![],
+                ports: Default::default(),
+                hosts: Default::default(),
+                dns: Default::default(),
+            },
+            context: String::new(),
+            context_path: "/tmp/context".to_string(),
+            portal: crate::portal::PortalConfig::default(),
+        };
+
+        let repos = RepoIdentifier::discover_repo_ids(&config).unwrap();
+        assert_eq!(repos.len(), 2);
+        assert_ne!(repos[0].source_path(&config), repos[1].source_path(&config));
+
+        std::fs::remove_dir_all(&temp_dir).ok();
     }
 }

--- a/common/src/repo.rs
+++ b/common/src/repo.rs
@@ -23,11 +23,15 @@ pub fn find_git_root() -> Result<PathBuf> {
         .map(|p: &std::path::Path| p.to_path_buf())
 }
 
-/// Prompt user to select from a list of repos
-fn prompt_select_repo(repos: Vec<RepoIdentifier>, prompt: &str) -> Result<RepoIdentifier> {
+/// Prompt user to select from a list of repos using inquire.
+fn prompt_select_repo(
+    config: &Config,
+    repos: Vec<RepoIdentifier>,
+    prompt: &str,
+) -> Result<RepoIdentifier> {
     let options: Vec<String> = repos
         .iter()
-        .map(|r| r.relative_path().display().to_string())
+        .map(|r| r.source_path(config).display().to_string())
         .collect();
 
     let selected = inquire::Select::new(prompt, options)
@@ -36,7 +40,7 @@ fn prompt_select_repo(repos: Vec<RepoIdentifier>, prompt: &str) -> Result<RepoId
 
     repos
         .into_iter()
-        .find(|r| r.relative_path().display().to_string() == selected)
+        .find(|r| r.source_path(config).display().to_string() == selected)
         .ok_or_else(|| eyre::eyre!("Selected repository not found"))
 }
 
@@ -61,9 +65,18 @@ pub fn locate_repo(config: &Config, search: Option<&str>) -> Result<RepoIdentifi
                 Some(s) => format!("Multiple repositories match '{}'. Select one:", s),
                 None => "Select a repository:".to_string(),
             };
-            prompt_select_repo(matches, &prompt)
+            prompt_select_repo(config, matches, &prompt)
         }
     }
+}
+
+/// Pick from all discovered repositories using the same interactive selector as locate_repo.
+pub fn pick_discovered_repo(config: &Config) -> Result<RepoIdentifier> {
+    let repos = RepoIdentifier::discover_repo_ids(config)?;
+    if repos.is_empty() {
+        bail!("No repositories discovered");
+    }
+    prompt_select_repo(config, repos, "Select a repository:")
 }
 
 /// Resolve repo argument to a RepoIdentifier

--- a/common/src/repo.rs
+++ b/common/src/repo.rs
@@ -128,12 +128,92 @@ pub fn resolve_repo_id(config: &Config, repo_name: Option<&str>) -> Result<RepoI
     let repo_id = match repo_name {
         Some(name) => locate_repo(config, Some(name)),
         None => {
-            let git_root = find_git_root(true)?;
-            RepoIdentifier::from_repo_path(config, &git_root)
+            // Prefer git root resolution (handles linked worktrees), then fall
+            // back to jj workspace root for jj-only repos.
+            let repo_root = find_git_root(true).or_else(|_| find_jj_workspace_root(true))?;
+            RepoIdentifier::from_repo_path(config, &repo_root)
         }
     };
     println!("debug: {repo_id:?}");
     repo_id
+}
+
+/// Find enclosing jj workspace root from current directory.
+///
+/// When `resolve_to_original_root` is true:
+/// - If `.jj/repo` is a file, resolve to the original workspace root.
+///
+/// When false:
+/// - Return the current workspace root (the ancestor containing `.jj`) even
+///   if it points to an original root.
+fn find_jj_workspace_root(resolve_to_original_root: bool) -> Result<PathBuf> {
+    let current = std::env::current_dir().wrap_err("Failed to get current working directory")?;
+    find_jj_workspace_root_from(&current, resolve_to_original_root)
+}
+
+fn find_jj_workspace_root_from(path: &Path, resolve_to_original_root: bool) -> Result<PathBuf> {
+    for ancestor in path.ancestors() {
+        let jj_dir = ancestor.join(".jj");
+        if !jj_dir.is_dir() {
+            continue;
+        }
+
+        let repo_entry = jj_dir.join("repo");
+
+        // Original workspace: `.jj/repo` is a directory
+        if repo_entry.is_dir() {
+            return ancestor.canonicalize().wrap_err_with(|| {
+                format!(
+                    "Failed to canonicalize jj workspace root: {}",
+                    ancestor.display()
+                )
+            });
+        }
+
+        // Linked workspace: `.jj/repo` is a file that points to
+        // `<original_root>/.jj/repo`.
+        if repo_entry.is_file() {
+            if !resolve_to_original_root {
+                return ancestor.canonicalize().wrap_err_with(|| {
+                    format!(
+                        "Failed to canonicalize jj workspace root: {}",
+                        ancestor.display()
+                    )
+                });
+            }
+
+            let raw = std::fs::read_to_string(&repo_entry)
+                .wrap_err_with(|| format!("Failed to read {}", repo_entry.display()))?;
+            let target = PathBuf::from(raw.trim());
+            let target_abs = if target.is_absolute() {
+                target
+            } else {
+                jj_dir.join(target)
+            };
+
+            let original_root = target_abs
+                .parent()
+                .and_then(|p| p.parent())
+                .ok_or_else(|| {
+                    eyre!(
+                        "Malformed jj repo pointer in {}: {}",
+                        repo_entry.display(),
+                        target_abs.display()
+                    )
+                })?;
+
+            return original_root.canonicalize().wrap_err_with(|| {
+                format!(
+                    "Failed to canonicalize resolved jj workspace root: {}",
+                    original_root.display()
+                )
+            });
+        }
+
+        // `.jj` exists but no recognizable `repo` entry; keep walking.
+    }
+
+    bail!("Failed to discover git repository or jj workspace from current directory")
 }
 
 /// Create a new workspace (git worktree or jj workspace)
@@ -370,4 +450,123 @@ pub fn remove_repo(config: &Config, repo_id: &RepoIdentifier, dry_run: bool) -> 
     println!("\n✓ All workspaces and repositories removed successfully");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RuntimeConfig;
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    fn cwd_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn make_test_config(base_repo_dir: PathBuf) -> Config {
+        Config {
+            workspace_dir: PathBuf::from("/workspaces"),
+            base_repo_dir,
+            repo_discovery_dirs: vec![],
+            repo_discovery_timeout_secs: 5,
+            default_profile: None,
+            profiles: HashMap::new(),
+            runtime: RuntimeConfig {
+                backend: "podman".to_string(),
+                image: "test:latest".to_string(),
+                entrypoint: None,
+                mounts: Default::default(),
+                env: vec![],
+                env_passthrough: vec![],
+                ports: vec![],
+                hosts: vec![],
+                dns: vec![],
+                skip_mounts: vec![],
+            },
+            context: String::new(),
+            context_path: "/tmp/context".to_string(),
+            portal: crate::portal::PortalConfig::default(),
+        }
+    }
+
+    #[test]
+    fn test_find_jj_workspace_root_from_nested_dir() {
+        let _guard = cwd_test_lock().lock().unwrap();
+        let temp = std::env::temp_dir().join(format!("ab-test-jj-root-{}", std::process::id()));
+        let repo = temp.join("repos").join("fr").join("agent-box");
+        let nested = repo.join("deep").join("child");
+        std::fs::create_dir_all(repo.join(".jj").join("repo")).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let old_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&nested).unwrap();
+
+        let found = find_jj_workspace_root(true).unwrap();
+        assert_eq!(found, repo.canonicalize().unwrap());
+
+        std::env::set_current_dir(old_cwd).unwrap();
+        std::fs::remove_dir_all(&temp).ok();
+    }
+
+    #[test]
+    fn test_resolve_repo_id_falls_back_to_jj_workspace_root() {
+        let _guard = cwd_test_lock().lock().unwrap();
+        let temp = std::env::temp_dir().join(format!(
+            "ab-test-resolve-jj-fallback-{}",
+            std::process::id()
+        ));
+        let base_repo_dir = temp.join("repos");
+        let repo = base_repo_dir.join("fr").join("agent-box");
+        let nested = repo.join("subdir");
+
+        std::fs::create_dir_all(repo.join(".jj").join("repo")).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let config = make_test_config(base_repo_dir.clone());
+
+        let old_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&nested).unwrap();
+
+        let repo_id = resolve_repo_id(&config, None).unwrap();
+
+        std::env::set_current_dir(old_cwd).unwrap();
+        std::fs::remove_dir_all(&temp).ok();
+
+        assert_eq!(repo_id.relative_path(), Path::new("fr/agent-box"));
+    }
+
+    #[test]
+    fn test_find_jj_workspace_root_from_linked_workspace_repo_file() {
+        let _guard = cwd_test_lock().lock().unwrap();
+        let temp = std::env::temp_dir().join(format!("ab-test-jj-linked-{}", std::process::id()));
+
+        let original_root = temp.join("repos").join("fr").join("agent-box");
+        let linked_ws = temp.join("ws").join("agent-box-ws");
+        let nested = linked_ws.join("nested");
+
+        std::fs::create_dir_all(original_root.join(".jj").join("repo")).unwrap();
+        std::fs::create_dir_all(linked_ws.join(".jj")).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        // Simulate jj linked workspace pointer: .jj/repo file pointing to
+        // <original_root>/.jj/repo (relative path).
+        std::fs::write(
+            linked_ws.join(".jj").join("repo"),
+            original_root.join(".jj").join("repo").display().to_string(),
+        )
+        .unwrap();
+
+        let old_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&nested).unwrap();
+
+        let found = find_jj_workspace_root(true).unwrap();
+        assert_eq!(found, original_root.canonicalize().unwrap());
+
+        let found_current = find_jj_workspace_root_from(&nested, false).unwrap();
+        assert_eq!(found_current, linked_ws.canonicalize().unwrap());
+
+        std::env::set_current_dir(old_cwd).unwrap();
+        std::fs::remove_dir_all(&temp).ok();
+    }
 }

--- a/common/src/repo.rs
+++ b/common/src/repo.rs
@@ -1,26 +1,68 @@
-use eyre::{OptionExt, Result, WrapErr, bail};
-use std::path::PathBuf;
+use eyre::{OptionExt, Result, WrapErr, bail, eyre};
+use gix::repository::Kind;
+use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 use crate::path::RepoIdentifier;
 use crate::path::path_to_str;
 
-/// Find the git root directory by traversing up from the current directory
-pub fn find_git_root() -> Result<PathBuf> {
+/// Find the git root directory from current directory.
+/// Set `resolve_linked_worktree_to_main_repo=true` to resolve linked worktrees
+/// to the main repository root.
+pub fn find_git_root(resolve_linked_worktree_to_main_repo: bool) -> Result<PathBuf> {
     let current_dir =
         std::env::current_dir().wrap_err("Failed to get current working directory")?;
+    find_git_root_from(&current_dir, resolve_linked_worktree_to_main_repo)
+}
 
-    let repo = gix::discover(&current_dir).wrap_err_with(|| {
-        format!(
-            "Failed to discover git repository in {}",
-            current_dir.display()
-        )
-    })?;
+/// Find git root from an arbitrary path.
+/// When `resolve_linked_worktree_to_main_repo` is true, linked worktrees are
+/// resolved to the main repository root via common_dir.
+pub fn find_git_root_from(
+    path: &Path,
+    resolve_linked_worktree_to_main_repo: bool,
+) -> Result<PathBuf> {
+    let repo = gix::discover(path)
+        .wrap_err_with(|| format!("Failed to discover git repository in {}", path.display()))?;
 
-    // Get the work tree path
-    repo.workdir()
-        .ok_or_eyre("Cannot work with a bare repository")
-        .map(|p: &std::path::Path| p.to_path_buf())
+    let root = match repo.kind() {
+        Kind::WorkTree { is_linked: true } if resolve_linked_worktree_to_main_repo => {
+            let common = repo.common_dir().canonicalize().wrap_err_with(|| {
+                format!(
+                    "Failed to canonicalize common_dir: {}",
+                    repo.common_dir().display()
+                )
+            })?;
+            let main_repo = gix::open(&common).wrap_err_with(|| {
+                format!(
+                    "Failed to open main repo from common_dir: {}",
+                    common.display()
+                )
+            })?;
+            main_repo
+                .workdir()
+                .ok_or_else(|| {
+                    eyre!(
+                        "Linked worktree's main repository at {} is bare and has no working directory",
+                        common.display()
+                    )
+                })
+                .map(|p| p.to_path_buf())?
+        }
+        Kind::Bare => {
+            bail!(
+                "Bare repository at {} has no working directory",
+                repo.git_dir().display()
+            )
+        }
+        _ => repo
+            .workdir()
+            .ok_or_eyre("Repository has no working directory")
+            .map(|p| p.to_path_buf())?,
+    };
+
+    root.canonicalize()
+        .wrap_err_with(|| format!("Failed to canonicalize repo root: {}", root.display()))
 }
 
 /// Prompt user to select from a list of repos using inquire.
@@ -86,7 +128,7 @@ pub fn resolve_repo_id(config: &Config, repo_name: Option<&str>) -> Result<RepoI
     let repo_id = match repo_name {
         Some(name) => locate_repo(config, Some(name)),
         None => {
-            let git_root = find_git_root()?;
+            let git_root = find_git_root(true)?;
             RepoIdentifier::from_repo_path(config, &git_root)
         }
     };

--- a/docs/src/reference/agent-box/config.md
+++ b/docs/src/reference/agent-box/config.md
@@ -19,6 +19,7 @@ Merge behavior:
 
 - `workspace_dir` (path): base directory for generated workspaces
 - `base_repo_dir` (path, default `/`): base directory for source repositories
+- `repo_discovery_dirs` (array of paths, default `[]`): extra roots searched for repo discovery in interactive selection/disambiguation (falls back to `base_repo_dir` when empty)
 - `default_profile` (string|null): profile automatically applied to `ab spawn`
 - `profiles` (table): named profile definitions
 - `runtime` (table): runtime/backend settings

--- a/docs/src/reference/agent-box/config.md
+++ b/docs/src/reference/agent-box/config.md
@@ -18,7 +18,7 @@ Merge behavior:
 ## Root keys
 
 - `workspace_dir` (path): base directory for generated workspaces
-- `base_repo_dir` (path): base directory for source repositories
+- `base_repo_dir` (path, default `/`): base directory for source repositories
 - `default_profile` (string|null): profile automatically applied to `ab spawn`
 - `profiles` (table): named profile definitions
 - `runtime` (table): runtime/backend settings

--- a/docs/src/reference/agent-box/config.md
+++ b/docs/src/reference/agent-box/config.md
@@ -20,6 +20,7 @@ Merge behavior:
 - `workspace_dir` (path): base directory for generated workspaces
 - `base_repo_dir` (path, default `/`): base directory for source repositories
 - `repo_discovery_dirs` (array of paths, default `[]`): extra roots searched for repo discovery in interactive selection/disambiguation (falls back to `base_repo_dir` when empty)
+- `repo_discovery_timeout_secs` (integer, default `5`): max total scan time for repository discovery before discovery aborts with timeout
 - `default_profile` (string|null): profile automatically applied to `ab spawn`
 - `profiles` (table): named profile definitions
 - `runtime` (table): runtime/backend settings


### PR DESCRIPTION
- make default `base_repo_dir` value to `/`, allowing any dir.
- add `repo_discovery_dirs` to allow for selective scanning of fs and keeping it performant since the default is now too broad. the discovery also comes with a timeout `repo_discovery_timeout_secs`(default 5s) to error early and report users to narrow down their discovery dirs, or to increase their timeout.
- `ab new` from workspace/worktree dir/subdirs now use the correct base repo to compute the repo id, via resolve_repo_id.